### PR TITLE
Pin toolchain nightly version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = ["clippy", "rustfmt"]
+channel = "nightly-2023-11-12"
+components = ["rust-src", "clippy", "rustfmt"]


### PR DESCRIPTION
This prevents toolchain bloat since otherwise dev will download a new toolchain everyday