### PR TITLE
fix: run cargo update on the server

### DIFF
--- a/crates/server/Cargo.lock
+++ b/crates/server/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "ft"
 version = "0.1.0"
-source = "git+https://github.com/nils-mathieu/libft-rs#b16b166f56f2b241e0d68faadb2fd257be64ba3b"
+source = "git+https://github.com/nils-mathieu/libft-rs#376d5144a81f28cbb78951d20b7af4bebc045d69"
 dependencies = [
  "bitflags",
  "libc",
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "server"
@@ -49,6 +49,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"


### PR DESCRIPTION
Updates the dependencies of the server to make sure we're using the latest version of everything, incuding libft-rs so it builds on the latest rustc version